### PR TITLE
stream from path or url when possible

### DIFF
--- a/lib/supplement/storages/ram.ex
+++ b/lib/supplement/storages/ram.ex
@@ -36,6 +36,12 @@ defmodule Capsule.Storages.RAM do
   def read(id, _opts \\ []),
     do: {:ok, id |> decode_pid! |> StringIO.contents() |> elem(0)}
 
+  @impl Storage
+  def url(path, opts \\ []), do: nil
+
+  @impl Storage
+  def path(path, opts \\ []), do: nil
+
   defp decompose_id(id), do: String.split(id, "/", parts: 2)
 
   defp decode_pid!(id) do

--- a/lib/supplement/uploads/plug_upload.ex
+++ b/lib/supplement/uploads/plug_upload.ex
@@ -1,4 +1,12 @@
 defimpl Capsule.Upload, for: Plug.Upload do
+
+  def path(%{path: path}) when is_binary(path) do
+    case File.exists?(path) do
+      {:error, reason} -> {:error, "Source file does not exist"}
+      success_tuple -> {:ok, path}
+    end
+  end
+  
   def contents(%{path: path}) do
     case File.read(path) do
       {:error, reason} -> {:error, "Could not read path: #{reason}"}

--- a/lib/supplement/uploads/uri.ex
+++ b/lib/supplement/uploads/uri.ex
@@ -19,5 +19,9 @@ defimpl Capsule.Upload, for: URI do
     end
   end
 
+  def path(_) do
+    nil
+  end
+
   def name(%{path: path}), do: Path.basename(path)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Supplement.MixProject do
   defp deps do
     [
       {:capsule, "~> 0.9"},
+      # {:capsule, path: "../capsule"},
       {:ex_aws, "~> 2.0", optional: true},
       {:ex_aws_s3, "~> 2.0", optional: true},
       {:mox, "~> 1.0", only: [:test]},

--- a/test/storages/disk_test.exs
+++ b/test/storages/disk_test.exs
@@ -37,13 +37,15 @@ defmodule Capsule.Storages.DiskTest do
     end
 
     test "overwrites existing file when force is set to true" do
-      File.write!("tmp/name", "data")
+      file = "tmp/name"
 
-      Disk.put(%MockUpload{name: "name", content: "new"}, force: true)
+      File.write!(file, "data")
 
-      assert "new" = File.read!("tmp/name")
+      Disk.put(%MockUpload{name: "name", content: "new", path: file}, force: true)
 
-      on_exit(fn -> File.rm!("tmp/name") end)
+      assert "new" = File.read!(file)
+
+      on_exit(fn -> File.rm!(file) end)
     end
   end
 

--- a/test/storages/s3_test.exs
+++ b/test/storages/s3_test.exs
@@ -8,13 +8,13 @@ defmodule Capsule.Storages.S3Test do
 
   describe "put/1" do
     test "returns success tuple" do
-      stub(ExAwsMock, :request, fn _ -> {:ok, nil} end)
+      stub(ExAwsMock, :request, fn _, _ -> {:ok, nil} end)
 
       assert {:ok, "/hi"} = S3.put(%MockUpload{})
     end
 
     test "returns error when request fails" do
-      stub(ExAwsMock, :request, fn _ -> {:error, nil} end)
+      stub(ExAwsMock, :request, fn _, _ -> {:error, nil} end)
 
       assert {:error, _} = S3.put(%MockUpload{})
     end
@@ -22,7 +22,7 @@ defmodule Capsule.Storages.S3Test do
 
   describe "put/2 with bucket override" do
     test "makes request with override value" do
-      stub(ExAwsMock, :request, fn %{bucket: "other"} -> {:ok, nil} end)
+      stub(ExAwsMock, :request, fn %{bucket: "other"}, _ -> {:ok, nil} end)
 
       assert {:ok, _} = S3.put(%MockUpload{}, bucket: "other")
     end
@@ -30,23 +30,23 @@ defmodule Capsule.Storages.S3Test do
 
   describe "put/2 with valid s3 option" do
     test "adds corresponding AWS header to request" do
-      stub(ExAwsMock, :request, fn %{headers: %{"x-amz-acl" => "public-read"}} -> {:ok, nil} end)
+      stub(ExAwsMock, :request, fn %{headers: %{"x-amz-acl" => "public-read"}}, _ -> {:ok, nil} end)
 
-      assert {:ok, _} = S3.put(%MockUpload{}, s3_options: [acl: "public-read"])
+      assert {:ok, _} = S3.put(%MockUpload{}, s3_options: [acl: "public-read"], upload_with: :contents)
     end
   end
 
   describe "put/2 with invalid s3 option" do
     test "is noop" do
-      stub(ExAwsMock, :request, fn %{headers: %{}} -> {:ok, nil} end)
+      stub(ExAwsMock, :request, fn %{headers: %{}}, _ -> {:ok, nil} end)
 
-      assert {:ok, _} = S3.put(%MockUpload{}, s3_options: [bad: "option"])
+      assert {:ok, _} = S3.put(%MockUpload{}, s3_options: [bad: "option"], upload_with: :contents)
     end
   end
 
   describe "read/1" do
     test "returns success tuple with data" do
-      stub(ExAwsMock, :request, fn _ -> {:ok, %{body: "data"}} end)
+      stub(ExAwsMock, :request, fn _, _ -> {:ok, %{body: "data"}} end)
 
       assert {:ok, "data"} = S3.read("fake")
     end
@@ -54,7 +54,7 @@ defmodule Capsule.Storages.S3Test do
 
   describe "read/2 with bucket override" do
     test "makes request with override value" do
-      stub(ExAwsMock, :request, fn %{bucket: "other"} -> {:ok, %{body: ""}} end)
+      stub(ExAwsMock, :request, fn %{bucket: "other"}, _ -> {:ok, %{body: ""}} end)
 
       assert {:ok, _} = S3.read("fake", bucket: "other")
     end
@@ -62,7 +62,7 @@ defmodule Capsule.Storages.S3Test do
 
   describe "copy/1" do
     test "returns success tuple" do
-      stub(ExAwsMock, :request, fn _ -> {:ok, nil} end)
+      stub(ExAwsMock, :request, fn _, _ -> {:ok, nil} end)
 
       assert {:ok, "new_path"} = S3.copy("/path", "new_path")
     end
@@ -70,7 +70,7 @@ defmodule Capsule.Storages.S3Test do
 
   describe "copy/2 with bucket override" do
     test "makes request with override value" do
-      stub(ExAwsMock, :request, fn %{bucket: "other"} -> {:ok, nil} end)
+      stub(ExAwsMock, :request, fn %{bucket: "other"}, _ -> {:ok, nil} end)
 
       assert {:ok, _} = S3.copy("fake", "new_path", bucket: "other")
     end

--- a/test/support/mock_upload.ex
+++ b/test/support/mock_upload.ex
@@ -1,8 +1,10 @@
 defmodule Capsule.MockUpload do
-  defstruct content: "Hi, I'm a file", name: "hi"
+  defstruct content: "Hi, I'm a file", name: "hi", path: "LICENSE"
 
   defimpl Capsule.Upload do
     def contents(mock), do: {:ok, mock.content}
+
+    def path(mock), do: {:ok, mock.path}
 
     def name(mock), do: mock.name
   end


### PR DESCRIPTION
- added `path`and `url` functions to access files without reading them
- add a new (default but overridable) way to upload files directly from the path rather than reading contents in memory, for S3 that means streaming the file up
- pass options to `ExAws.request/2`
- other small tweaks
- adapted tests to match